### PR TITLE
Update bot.send_embed() to use message.respond() when needed.

### DIFF
--- a/bot/cogs/database.py
+++ b/bot/cogs/database.py
@@ -17,6 +17,8 @@ class Database(commands.Cog):
         self.cursor.execute(
             f"CREATE TABLE IF NOT EXISTS users ({','.join(user_fields)})")
         self.emojis = self.bot.get_cog('Emojis')
+        # Expose self to other cogs.
+        self.bot.database = self
 
     def add_user(self, user):
         """ Adds a new user to the database """

--- a/bot/dotabot.py
+++ b/bot/dotabot.py
@@ -1,11 +1,10 @@
-import argparse
 import logging
 import os
+import random
 import sys
-from random import randint
 
 import discord
-from discord.ext import commands
+from discord.commands.context import ApplicationContext
 
 # Get secret tokens from environment variables.
 DISCORD_CLIENT_ID = os.environ.get('DISCORD_CLIENT_ID')

--- a/bot/dotabot.py
+++ b/bot/dotabot.py
@@ -126,11 +126,7 @@ class DotaBot(discord.Bot):
             # print "This interaction failed" to the user.
             if type(channel) == ApplicationContext:
                 response = await channel.respond(embed=embed)
-                logging.debug(f"send_embed() -> {response}")
                 return
-            else:
-                logging.debug(
-                    f"send_embed() -> type(channel): {type(channel)}")
 
             # Send the single message
             return await channel.send(embed=embed)
@@ -193,7 +189,6 @@ class DotaBot(discord.Bot):
             message_index = message_index + 1
 
         # Return the last message sent so reactions can be easily added
-        logging.debug(f"send_embed() -> {response}")
         return response
 
     async def add_reactions(self, message, emojis):


### PR DESCRIPTION
If we don't `.respond()` to a slash command, discord will print to the user: `This interaction failed` even though it sent a message.

\+ also expose the database cog to other cogs via bot.database